### PR TITLE
feat: Add user ids to query to add 'reach' information to summary

### DIFF
--- a/query.py
+++ b/query.py
@@ -3,6 +3,30 @@ import json
 
 from github import Github
 
+
+def get_page(paginated_list):
+    """
+    Take a github.PaginatedList.PaginatedList and then iterate through the
+    pages to get all of its entries
+
+    Args:
+        paginated_list (github.PaginatedList.PaginatedList): PyGithub paginated
+         list object
+
+    Returns:
+        `list`: All entries in the paginated list
+    """
+    idx = 0
+    _page_entries = paginated_list.get_page(idx)
+    page_entries = []
+    while _page_entries:
+        page_entries.extend(_page_entries)
+        idx += 1
+        _page_entries = paginated_list.get_page(idx)
+
+    return page_entries
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Query the GitHub API for information on repositories."
@@ -53,10 +77,15 @@ if __name__ == "__main__":
     for repo_name in repo_names:
         repo = github_api.get_repo(repo_name)
         data[repo_name] = {
-            "stars": repo.stargazers_count,
-            "watchers": repo.subscribers_count,
-            "forks": repo.forks_count,
+            "star_count": repo.stargazers_count,
+            "watcher_count": repo.subscribers_count,
+            "fork_count": repo.forks_count,
             "releases": repo.get_releases().totalCount,
+            "stargazer_ids": [
+                stargazer.id for stargazer in get_page(repo.get_stargazers())
+            ],
+            "watcher_ids": [watcher.id for watcher in get_page(repo.get_subscribers())],
+            "fork_owner_ids": [fork.owner.id for fork in get_page(repo.get_forks())],
         }
 
     with open("repo_data.json", "w") as write_file:

--- a/summary.py
+++ b/summary.py
@@ -5,9 +5,9 @@ if __name__ == "__main__":
     with open(Path().cwd().joinpath("repo_data.json")) as read_file:
         data = json.load(read_file)
 
-    summary_table = f"{'GitHub repository':81} | {'Stars':5} | {'Watch':5} | {'Forks':5} | {'Reach':5}\n"
+    summary_table = f"{'GitHub repository':81} | {'Stars':5} | {'Watchers':8} | {'Forks':5} | {'Reach':5}\n"
     # Ending header with colon right aligns
-    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
+    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 8}:|-{'-' * 5}:|-{'-' * 4}:\n"
 
     all_stars = set()
     all_watchers = set()
@@ -28,7 +28,7 @@ if __name__ == "__main__":
             reach_count = len(reach)
 
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
-            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5} | {reach_count:5}\n"
+            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:8} | {fork_count:5} | {reach_count:5}\n"
 
             all_stars.update(stargazer_ids)
             all_watchers.update(watcher_ids)
@@ -36,8 +36,8 @@ if __name__ == "__main__":
 
     all_reach = all_stars | all_watchers | all_forks
 
-    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
-    summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {len(all_stars):5} | {len(all_watchers):5} | {len(all_forks):5} | {len(all_reach):5}\n"
+    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 8}:|-{'-' * 5}:|-{'-' * 4}:\n"
+    summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {len(all_stars):5} | {len(all_watchers):8} | {len(all_forks):5} | {len(all_reach):5}\n"
 
     for repo in data:
         if repo == "root-project/root":
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             reach_count = len(reach)
 
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
-            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5} | {reach_count:5}\n"
+            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:8} | {fork_count:5} | {reach_count:5}\n"
 
     with open("summary.md", "w") as write_file:
         write_file.write("\n## Summary Table\n\n")

--- a/summary.py
+++ b/summary.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 if __name__ == "__main__":
     with open(Path().cwd().joinpath("repo_data.json")) as read_file:
-        repo_data = json.load(read_file)
+        data = json.load(read_file)
 
     summary_table = (
         f"{'GitHub repository':81} | {'Stars':5} | {'Watch':5} | {'Forks':5}\n"
@@ -14,32 +14,42 @@ if __name__ == "__main__":
     all_stars = 0
     all_watchers = 0
     all_forks = 0
-    for repo in repo_data:
+    for repo in data:
         if repo != "root-project/root":
-            stars = repo_data[repo]["stars"]
-            watchers = repo_data[repo]["watchers"]
-            forks = repo_data[repo]["forks"]
-            repo_markdown_link = f"[{repo}](https://github.com/{repo})"
-            summary_table += (
-                f"{repo_markdown_link:81} | {stars:5} | {watchers:5} | {forks:5}\n"
-            )
+            repo_data = data[repo]
 
-            all_stars += stars
-            all_watchers += watchers
-            all_forks += forks
+            stargazer_ids = set(repo_data["stargazer_ids"])
+            watcher_ids = set(repo_data["watcher_ids"])
+            fork_owner_ids = set(repo_data["fork_owner_ids"])
+            reach = stargazer_ids | watcher_ids | fork_owner_ids
+
+            star_count = repo_data["star_count"]
+            watcher_count = repo_data["watcher_count"]
+            fork_count = repo_data["fork_count"]
+            repo_markdown_link = f"[{repo}](https://github.com/{repo})"
+            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5}\n"
+
+            all_stars += star_count
+            all_watchers += watcher_count
+            all_forks += fork_count
 
     summary_table += f"{'-' * 81}-|-{'-' * 5}-|-{'-' * 5}-|-{'-' * 5}\n"
     summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {all_stars:5} | {all_watchers:5} | {all_forks:5}\n"
 
-    for repo in repo_data:
+    for repo in data:
         if repo == "root-project/root":
-            stars = repo_data[repo]["stars"]
-            watchers = repo_data[repo]["watchers"]
-            forks = repo_data[repo]["forks"]
+            repo_data = data[repo]
+
+            stargazer_ids = set(repo_data["stargazer_ids"])
+            watcher_ids = set(repo_data["watcher_ids"])
+            fork_owner_ids = set(repo_data["fork_owner_ids"])
+            reach = stargazer_ids | watcher_ids | fork_owner_ids
+
+            star_count = repo_data["star_count"]
+            watcher_count = repo_data["watcher_count"]
+            fork_count = repo_data["fork_count"]
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
-            summary_table += (
-                f"{repo_markdown_link:81} | {stars:5} | {watchers:5} | {forks:5}\n"
-            )
+            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5}\n"
 
     with open("summary.md", "w") as write_file:
         write_file.write("\n## Summary Table\n\n")

--- a/summary.py
+++ b/summary.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     with open(Path().cwd().joinpath("repo_data.json")) as read_file:
         data = json.load(read_file)
 
-    summary_table = f"{'GitHub repository':81} | {'Stars':5} | {'Watch':5} | {'Forks':5}| {'Reach':5}\n"
+    summary_table = f"{'GitHub repository':81} | {'Stars':5} | {'Watch':5} | {'Forks':5} | {'Reach':5}\n"
     # Ending header with colon right aligns
     summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
 

--- a/summary.py
+++ b/summary.py
@@ -5,15 +5,14 @@ if __name__ == "__main__":
     with open(Path().cwd().joinpath("repo_data.json")) as read_file:
         data = json.load(read_file)
 
-    summary_table = (
-        f"{'GitHub repository':81} | {'Stars':5} | {'Watch':5} | {'Forks':5}\n"
-    )
+    summary_table = f"{'GitHub repository':81} | {'Stars':5} | {'Watch':5} | {'Forks':5}| {'Reach':5}\n"
     # Ending header with colon right aligns
-    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
+    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
 
     all_stars = 0
     all_watchers = 0
     all_forks = 0
+    all_reach = 0
     for repo in data:
         if repo != "root-project/root":
             repo_data = data[repo]
@@ -21,20 +20,22 @@ if __name__ == "__main__":
             stargazer_ids = set(repo_data["stargazer_ids"])
             watcher_ids = set(repo_data["watcher_ids"])
             fork_owner_ids = set(repo_data["fork_owner_ids"])
-            reach = stargazer_ids | watcher_ids | fork_owner_ids
 
             star_count = repo_data["star_count"]
             watcher_count = repo_data["watcher_count"]
             fork_count = repo_data["fork_count"]
+            reach_count = len(stargazer_ids | watcher_ids | fork_owner_ids)
+
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
-            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5}\n"
+            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5} | {reach_count:5}\n"
 
             all_stars += star_count
             all_watchers += watcher_count
             all_forks += fork_count
+            all_reach += reach_count
 
-    summary_table += f"{'-' * 81}-|-{'-' * 5}-|-{'-' * 5}-|-{'-' * 5}\n"
-    summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {all_stars:5} | {all_watchers:5} | {all_forks:5}\n"
+    summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
+    summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {all_stars:5} | {all_watchers:5} | {all_forks:5} | {all_reach:5}\n"
 
     for repo in data:
         if repo == "root-project/root":
@@ -43,13 +44,14 @@ if __name__ == "__main__":
             stargazer_ids = set(repo_data["stargazer_ids"])
             watcher_ids = set(repo_data["watcher_ids"])
             fork_owner_ids = set(repo_data["fork_owner_ids"])
-            reach = stargazer_ids | watcher_ids | fork_owner_ids
 
             star_count = repo_data["star_count"]
             watcher_count = repo_data["watcher_count"]
             fork_count = repo_data["fork_count"]
+            reach_count = len(stargazer_ids | watcher_ids | fork_owner_ids)
+
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
-            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5}\n"
+            summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5} | {reach_count:5}\n"
 
     with open("summary.md", "w") as write_file:
         write_file.write("\n## Summary Table\n\n")

--- a/summary.py
+++ b/summary.py
@@ -14,13 +14,7 @@ if __name__ == "__main__":
     all_forks = set()
 
     for repo in data:
-        if repo not in [
-            "iris-hep/func_adl_servicex",
-            "iris-hep/func_adl_uproot",
-            "iris-hep/func_adl_xAOD",
-            "root-project/root",
-        ]:
-            # if repo != "root-project/root":
+        if repo != "root-project/root":
             repo_data = data[repo]
 
             stargazer_ids = set(repo_data["stargazer_ids"])

--- a/summary.py
+++ b/summary.py
@@ -57,7 +57,15 @@ if __name__ == "__main__":
             summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:8} | {fork_count:5} | {reach_count:5}\n"
 
     with open("summary.md", "w") as write_file:
-        write_file.write("\n## Summary Table\n\n")
+        file_str = "\n## Summary Table\n\n"
+        file_str += "* **Stars**: Number of stars the project has on GitHub\n"
+        file_str += "* **Watchers**: Number of watchers the project has on GitHub\n"
+        file_str += "* **Forks**: Number of forks of the project on GitHub\n"
+        file_str += "* **Reach**: The number of unique GitHub users who have"
+        file_str += " either starred, watched, or forked the project\n"
+        file_str += "\n"
+
+        write_file.write(file_str)
         write_file.write(summary_table)
 
     print(summary_table)

--- a/summary.py
+++ b/summary.py
@@ -9,33 +9,41 @@ if __name__ == "__main__":
     # Ending header with colon right aligns
     summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
 
-    all_stars = 0
-    all_watchers = 0
-    all_forks = 0
-    all_reach = 0
+    all_stars = set()
+    all_watchers = set()
+    all_forks = set()
+
     for repo in data:
-        if repo != "root-project/root":
+        if repo not in [
+            "iris-hep/func_adl_servicex",
+            "iris-hep/func_adl_uproot",
+            "iris-hep/func_adl_xAOD",
+            "root-project/root",
+        ]:
+            # if repo != "root-project/root":
             repo_data = data[repo]
 
             stargazer_ids = set(repo_data["stargazer_ids"])
             watcher_ids = set(repo_data["watcher_ids"])
             fork_owner_ids = set(repo_data["fork_owner_ids"])
+            reach = stargazer_ids | watcher_ids | fork_owner_ids
 
             star_count = repo_data["star_count"]
             watcher_count = repo_data["watcher_count"]
             fork_count = repo_data["fork_count"]
-            reach_count = len(stargazer_ids | watcher_ids | fork_owner_ids)
+            reach_count = len(reach)
 
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
             summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5} | {reach_count:5}\n"
 
-            all_stars += star_count
-            all_watchers += watcher_count
-            all_forks += fork_count
-            all_reach += reach_count
+            all_stars.update(stargazer_ids)
+            all_watchers.update(watcher_ids)
+            all_forks.update(fork_owner_ids)
+
+    all_reach = all_stars | all_watchers | all_forks
 
     summary_table += f"{'-' * 81}-|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 5}:|-{'-' * 4}:\n"
-    summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {all_stars:5} | {all_watchers:5} | {all_forks:5} | {all_reach:5}\n"
+    summary_table += f"{'All IRIS-HEP Analysis Systems':81} | {len(all_stars):5} | {len(all_watchers):5} | {len(all_forks):5} | {len(all_reach):5}\n"
 
     for repo in data:
         if repo == "root-project/root":
@@ -44,11 +52,12 @@ if __name__ == "__main__":
             stargazer_ids = set(repo_data["stargazer_ids"])
             watcher_ids = set(repo_data["watcher_ids"])
             fork_owner_ids = set(repo_data["fork_owner_ids"])
+            reach = stargazer_ids | watcher_ids | fork_owner_ids
 
             star_count = repo_data["star_count"]
             watcher_count = repo_data["watcher_count"]
             fork_count = repo_data["fork_count"]
-            reach_count = len(stargazer_ids | watcher_ids | fork_owner_ids)
+            reach_count = len(reach)
 
             repo_markdown_link = f"[{repo}](https://github.com/{repo})"
             summary_table += f"{repo_markdown_link:81} | {star_count:5} | {watcher_count:5} | {fork_count:5} | {reach_count:5}\n"


### PR DESCRIPTION
Resolves #2 

Add "reach" information to the summary table by altering the information returned in `query.py` to also include lists of the GitHub user ids corresponding to stars, watchers, and fork owners. Additionally, ensure the number of summary entries for all IRIS-HEP Analysis Systems projects is actually an intersection and not a union. Also add some summary components to the table Markdown.

```
* Add get_page function to be able to iterate through PyGithub paginated list objects and get all entries
   - Iterating over these object can then be used to get the GitHub user ids that are of interest
* Change repo_data.json keys to be more explicit
* Add 'reach' information to summary tables
   - "Reach" is the number of unique GitHub users who have either starred, watched, or forked a project
* Ensure the number of summary entries for all IRIS-HEP Analysis Systems projects is actually an intersection and not a union
```