### PR TITLE
feat: Include daily summary in time-series deploy for git scraping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
         cp summary-time-series.csv time-series/
         ls -lhtra time-series
 
-        echo "::set-output name=datetime::$(date --utc '+%Y-%m-%d %H:%M:%S %Z')"
+        echo "::set-output name=datetime::$(date --utc '+%Y-%m-%d %H:%M %Z')"
 
     - name: Deploy summary to GitHub Pages
       # if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
           --out-csv summary-time-series.csv
 
     - name: Setup files to deploy
-      id: prep
+      id: prepare
       run: |
         cat summary.md >> README.md
         mkdir deploy
@@ -77,7 +77,7 @@ jobs:
         force_orphan: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: 'Deploy to GitHub pages $(date --utc)'
+        commit_message: Deploy to GitHub pages ${{ steps.prepare.outputs.datetime }}
 
     - name: Deploy time series
       if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Summary
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
     branches:
     - main
@@ -68,7 +68,7 @@ jobs:
         echo "::set-output name=datetime::$(date --utc '+%Y-%m-%d %H:%M %Z')"
 
     - name: Deploy summary to GitHub Pages
-      # if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
         force_orphan: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy to GitHub pages ${{ steps.prepare.outputs.datetime }}
+        commit_message: Deploy to GitHub pages
 
     - name: Deploy time series
       if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
         ls -lhtra deploy
 
         mkdir time-series
+        cp summary.csv time-series/
         cp summary-time-series.csv time-series/
         ls -lhtra time-series
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Summary
 
 on:
   push:
-    branches:
-    - main
+    # branches:
+    # - main
   pull_request:
     branches:
     - main
@@ -65,7 +65,7 @@ jobs:
         ls -lhtra time-series
 
     - name: Deploy summary to GitHub Pages
-      if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      # if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
         force_orphan: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy to GitHub pages
+        commit_message: Deploy to GitHub pages $(date --utc)
 
     - name: Deploy time series
       if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,4 +90,4 @@ jobs:
         force_orphan: false  # get commit history
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy time series summary
+        commit_message: Deploy time series summary ${{ steps.prepare.outputs.datetime }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           --out-csv summary-time-series.csv
 
     - name: Setup files to deploy
+      id: prep
       run: |
         cat summary.md >> README.md
         mkdir deploy
@@ -64,6 +65,8 @@ jobs:
         cp summary-time-series.csv time-series/
         ls -lhtra time-series
 
+        echo "::set-output name=datetime::$(date --utc)"
+
     - name: Deploy summary to GitHub Pages
       # if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
@@ -74,7 +77,7 @@ jobs:
         force_orphan: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy to GitHub pages $(date --utc)
+        commit_message: 'Deploy to GitHub pages $(date --utc)'
 
     - name: Deploy time series
       if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
         cp summary-time-series.csv time-series/
         ls -lhtra time-series
 
-        echo "::set-output name=datetime::$(date --utc)"
+        echo "::set-output name=datetime::$(date --utc '+%Y-%m-%d %H:%M:%S %Z')"
 
     - name: Deploy summary to GitHub Pages
       # if: success() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
To do proper [Git scraping](https://simonwillison.net/2020/Oct/9/git-scraping/) the diffs themselves are helpful, beyond just the addition that happens daily in `summary-time-series.csv`. So add `summary.csv` to the deploy to the `time-series` branch which is versioned. Additionally add a datetime to the deploy commit message to make it visually easier to parse.

```
* Add summary.csv to the scheduled deploy to the time-series branch to version it for proper Git scraping
* Add YYYY-MM-DD HH:MM datetime stamp to time-series deploy commit message to make it easier to parse the git log visually
```