### PR TITLE
feat: Update repo list to reflect cabinetry joining Scikit-HEP

### DIFF
--- a/query.py
+++ b/query.py
@@ -42,7 +42,6 @@ if __name__ == "__main__":
     repo_names = [
         "GooFit/AmpGen",
         "GooFit/GooFit",
-        "scikit-hep/cabinetry",
         "diana-hep/excursion",
         "diana-hep/madminer",
         "gordonwatts/hep_tables",
@@ -58,6 +57,7 @@ if __name__ == "__main__":
         "scikit-hep/awkward-0.x",
         "scikit-hep/awkward-1.0",
         "scikit-hep/boost-histogram",
+        "scikit-hep/cabinetry",
         "scikit-hep/cookie",
         "scikit-hep/decaylanguage",
         "scikit-hep/fastjet",

--- a/query.py
+++ b/query.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     repo_names = [
         "GooFit/AmpGen",
         "GooFit/GooFit",
-        "alexander-held/cabinetry",
+        "scikit-hep/cabinetry",
         "diana-hep/excursion",
         "diana-hep/madminer",
         "gordonwatts/hep_tables",


### PR DESCRIPTION
`cabinetry` is now part of Scikit-HEP (welcome @alexander-held :slightly_smiling_face:), so update the repository list to reflect this.

```
* Update repository list to have cabinetry be under the Scikit-HEP GitHub org
```