### PR TITLE
fix: Properly update DataFrame when dates are the same

### DIFF
--- a/time_series.py
+++ b/time_series.py
@@ -32,7 +32,11 @@ if __name__ == "__main__":
     if current_df.date.isin(update_df.date)[0]:
         # Overwrite dataframe with current values
         selection = update_df["date"] == current_df["date"][0]
-        update_df[selection] = current_df
+        # inelegant solution
+        for key in update_df.keys():
+            update_df[selection] = update_df[selection].replace(
+                update_df[selection][key].values, current_df[key].values
+            )
     else:
         # Append current values
         update_df = pd.concat([update_df, current_df])

--- a/time_series.py
+++ b/time_series.py
@@ -30,13 +30,9 @@ if __name__ == "__main__":
     current_df = pd.read_csv(args.join_csv)
 
     if current_df.date.isin(update_df.date)[0]:
-        # Overwrite dataframe with current values
         selection = update_df["date"] == current_df["date"][0]
-        # inelegant solution
-        for key in update_df.keys():
-            update_df[selection] = update_df[selection].replace(
-                update_df[selection][key].values, current_df[key].values
-            )
+        # Overwrite dataframe with current values
+        update_df.loc[selection, update_df.keys()] = current_df[update_df.keys()].values
     else:
         # Append current values
         update_df = pd.concat([update_df, current_df])

--- a/time_series.py
+++ b/time_series.py
@@ -30,8 +30,8 @@ if __name__ == "__main__":
     current_df = pd.read_csv(args.join_csv)
 
     if current_df.date.isin(update_df.date)[0]:
-        selection = update_df["date"] == current_df["date"][0]
         # Overwrite dataframe with current values
+        selection = update_df["date"] == current_df["date"][0]
         update_df.loc[selection, update_df.keys()] = current_df[update_df.keys()].values
     else:
         # Append current values


### PR DESCRIPTION
```
* Update input DataFrame when the join DataFrame has the same date
as the input DataFrame. This happens if there are reruns of the
pipeline on the same day.

Co-authored-by: dantrim <dantrim1023@gmail.com>
```