### PR TITLE
feat: Add time series plots to daily summary page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,15 +51,24 @@ jobs:
           --join-csv summary.csv \
           --out-csv summary-time-series.csv
 
+    - name: Generate time series plots
+      run: |
+        python plots.py
+        mkdir img
+        mv *.png img/
+
     - name: Setup files to deploy
       id: prepare
       run: |
         cat summary.md >> README.md
+        cat time_series.md >> README.md
+
         mkdir deploy
         cp README.md deploy/
         cp repo_data.json deploy/
         cp summary.csv deploy/
         cp summary.md deploy/
+        cp -r img deploy/
         ls -lhtra deploy
 
         mkdir time-series

--- a/plots.py
+++ b/plots.py
@@ -1,0 +1,90 @@
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def project_timeseries(df, value, **kwargs):
+    scale_factor = 2.5
+    fig, (ax, legend_ax) = plt.subplots(
+        ncols=2,
+        figsize=(6 * scale_factor, 4 * scale_factor),
+        gridspec_kw={"width_ratios": [4, 1]},
+    )
+
+    time_fmt = mdates.AutoDateLocator()
+    ax.xaxis.set_major_locator(time_fmt)
+
+    projects = time_series_df.sort_values(value, ascending=False)[
+        "repositories"
+    ].unique()
+    if exclude_list := kwargs.pop("exclude", None):
+        for project in exclude_list:
+            projects = np.delete(projects, np.where(projects == project))
+
+    plot_style = kwargs.pop("plot_style", "line")
+    for idx, project in enumerate(projects):
+        selection = df["repositories"] == project
+        plot_kwargs = {"color": None if idx < 15 else "black"}
+
+        if plot_style == "scatter":
+            ax.scatter(
+                df[selection]["date"],
+                df[selection][value],
+                label=project,
+                **plot_kwargs,
+            )
+        else:
+            plot_kwargs["linewidth"] = kwargs.get("linewidth", 3)
+            ax.plot(
+                df[selection]["date"],
+                df[selection][value],
+                label=project,
+                **plot_kwargs,
+            )
+
+    handles, labels = ax.get_legend_handles_labels()
+    legend_ax.legend(handles, labels, borderaxespad=0)
+    legend_ax.axis("off")
+
+    xlabel = kwargs.pop("xlabel", "Date")
+    ax.set_xlabel(xlabel, size=14)
+    ylabel = kwargs.pop("ylabel", f"Number of {value}")
+    ax.set_ylabel(ylabel, size=14)
+
+    fig.tight_layout()
+    fig.savefig(f"time_series_{value}.png", facecolor="white")
+
+
+def write_markdown_section(df):
+
+    dates = df["date"]
+
+    with open("time_series.md", "w") as write_file:
+        file_str = "\n## Time Series Plots\n"
+        file_str = f"\nCovering dates from **{dates.min()}** to **{dates.max()}**\n"
+
+        plots = ["stars", "forks", "watchers"]
+        base_url = "https://raw.githubusercontent.com/iris-hep/analysis-community-summary/gh-pages/"
+        for plot in plots:
+            file_str += f"\n### {plot.capitalize()}\n\n"
+            file_str += f"![{plot}]({base_url}/img/time_series_{plot}.png)\n"
+
+        file_str += "\n"
+
+        write_file.write(file_str)
+
+
+if __name__ == "__main__":
+    time_series_df = pd.read_csv("summary-time-series.csv", parse_dates=True)
+
+    exclude_list = [
+        "All IRIS-HEP Analysis Systems",
+        "root-project/root",
+        "alexander-held/cabinetry",
+    ]
+    project_timeseries(time_series_df, "stars", exclude=exclude_list)
+    project_timeseries(time_series_df, "forks", exclude=exclude_list)
+    project_timeseries(time_series_df, "watchers", exclude=exclude_list)
+
+    write_markdown_section(time_series_df)

--- a/plots.py
+++ b/plots.py
@@ -65,7 +65,7 @@ def write_markdown_section(df):
         file_str = f"\nCovering dates from **{dates.min()}** to **{dates.max()}**\n"
 
         plots = ["stars", "forks", "watchers"]
-        base_url = "https://raw.githubusercontent.com/iris-hep/analysis-community-summary/gh-pages/"
+        base_url = "https://raw.githubusercontent.com/iris-hep/analysis-community-summary/gh-pages"
         for plot in plots:
             file_str += f"\n### {plot.capitalize()}\n\n"
             file_str += f"![{plot}]({base_url}/img/time_series_{plot}.png)\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyGithub~=1.55.0
 pandas~=1.3.3
 tabulate~=0.8.9  # Required for df.to_markdown
+matplotlib~=3.5.1


### PR DESCRIPTION
Addresses part of Issue #7.

```
* Add script to plot time series plot of the projects for various
metrics over. Also write out Markdown with the (remote) plots embedded.
* Add matplotlib as a requirement.
* Add plot generation to deployment CI/CD.
```