### PR TITLE
fix: Inject newline during concatenate for table web render

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
       shell: bash
       run: |
         cat summary.md >> README.md
+        printf "\n" >> README.md
         cat time_series.md >> README.md
 
         mkdir deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
 
     - name: Setup files to deploy
       id: prepare
+      shell: bash
       run: |
         cat summary.md >> README.md
         cat time_series.md >> README.md


### PR DESCRIPTION
```
* Inject a newline between cating summary.md and time_series.md
together so that there is space between the end of the summary table
and the start of the time series plots section. Without this space the table
will not render correctly on the web, though it will render fine if rendering
the Markdown alone.
* Explicitly set shell to Bash.
```